### PR TITLE
Automatically initialize autocompletes

### DIFF
--- a/client/app.js
+++ b/client/app.js
@@ -46,8 +46,43 @@ $(function() {
         }
     });
   });
+
+  animateAutocompletes();
 });
 
+function animateAutocompletes() {
+  const selector = '[data-behaviour="autocomplete"]';
+  activateForChildren(document);
+
+  let observer = new MutationObserver(mutations => {
+    for (let mutation of mutations) {
+      for (let node of mutation.addedNodes) {
+        if (!(node instanceof HTMLElement)) continue;
+
+        if (node.matches(selector)) activateAutocomplete(node);
+        else activateForChildren(node);
+      }
+    }
+  });
+
+  observer.observe(document.body, { childList: true, subtree: true });
+
+  function activateForChildren(node) {
+    for (let child of node.querySelectorAll(selector))
+      activateAutocomplete(child);
+  }
+
+  function activateAutocomplete(node) {
+    const callback  = (node.dataset || {}).callback;
+    const url = [window.location.pathname, 'callback', callback].join('/');
+
+    $(node).autoComplete({ resolverSettings: {
+      method: 'post',
+      url: url,
+      queryKey: 'data'
+    }});
+  }
+}
 
 function processAction(el) {
   const element = $(el);


### PR DESCRIPTION
Пример использования:

```js
const h = require('@snooty/html');
const db = require('@snooty/db');
const helpers = require('../lib/helpers');

const  { layout } = helpers;

module.exports = function(page) {
  page.route('/dicts/organizations');
  page.callback(autocomplete);

  page.content(layout({
    title: 'Организации',
    content: h('select.form-control', {
      'name': 'company',
      'data-behaviour': 'autocomplete',
      'data-callback': 'autocomplete'
    })
  }));
};

async function autocomplete(state) {
  const { data } = state;

  const pattern = db.escape(`%${data}%`);
  const matching = await db.dataset('companies').all(`name LIKE ${pattern}`);
  const choices = matching.map(({ id, name }) => ({ value: id, text: name }));

  state.send(choices);
}
```