### PR TITLE
Allow specifying row id field for grid via `idField` option

### DIFF
--- a/client/app.js
+++ b/client/app.js
@@ -59,12 +59,15 @@ $(function() {
     const gridOptions = {
       rowModelType,
       datasource,
+      getRowNodeId: (row => row.id)
     };
 
     attachListeners(gridOptions, gridDiv);
 
     Object.keys(gridDefinition).forEach(key => {
-      gridOptions[key] = gridDefinition[key];
+      const val = gridDefinition[key];
+      if (key === 'idField') gridOptions.getRowNodeId = (row => row[val]);
+      else gridOptions[key] = val;
     });
 
     const columnDefs = gridDefinition.columnDefs;

--- a/client/app.js
+++ b/client/app.js
@@ -66,6 +66,7 @@ $(function() {
 
     Object.keys(gridDefinition).forEach(key => {
       const val = gridDefinition[key];
+
       if (key === 'idField') gridOptions.getRowNodeId = (row => row[val]);
       else gridOptions[key] = val;
     });


### PR DESCRIPTION
The default value is `id`, so if members of your `rowData` collection already have a field named `id`, you need nothing to do
